### PR TITLE
Fix negative string index

### DIFF
--- a/lib/rain.c
+++ b/lib/rain.c
@@ -415,14 +415,14 @@ void rain_get(box *ret, box *table, box *key) {
       char *buf = malloc(2);
       buf[0] = table->data.s[key->data.si];
       buf[1] = 0;
-      rain_set_strcpy(ret, buf, 2);
+      rain_set_strcpy(ret, buf, 1);
       free(buf);
     }
     else if(key->data.si < 0 && key->data.si >= -(table->size)) {
       char *buf = malloc(2);
       buf[0] = table->data.s[table->size + key->data.si];
       buf[1] = 0;
-      rain_set_strcpy(ret, buf, 2);
+      rain_set_strcpy(ret, buf, 1);
       free(buf);
     }
     return;

--- a/lib/rain.c
+++ b/lib/rain.c
@@ -412,18 +412,10 @@ column *rain_has(box *table, box *key) {
 void rain_get(box *ret, box *table, box *key) {
   if(BOX_IS(table, STR) && BOX_IS(key, INT)) {
     if(key->data.si >= 0 && key->data.si < table->size) {
-      char *buf = malloc(2);
-      buf[0] = table->data.s[key->data.si];
-      buf[1] = 0;
-      rain_set_strcpy(ret, buf, 1);
-      free(buf);
+      rain_set_strcpy(ret, table->data.s + key->data.si, 1);
     }
     else if(key->data.si < 0 && key->data.si >= -(table->size)) {
-      char *buf = malloc(2);
-      buf[0] = table->data.s[table->size + key->data.si];
-      buf[1] = 0;
-      rain_set_strcpy(ret, buf, 1);
-      free(buf);
+      rain_set_strcpy(ret, table->data.s + table->size + key->data.si, 1);
     }
     return;
   }

--- a/lib/rain.c
+++ b/lib/rain.c
@@ -412,14 +412,18 @@ column *rain_has(box *table, box *key) {
 void rain_get(box *ret, box *table, box *key) {
   if(BOX_IS(table, STR) && BOX_IS(key, INT)) {
     if(key->data.si >= 0 && key->data.si < table->size) {
-      ret->type = ITYP_STR;
-      ret->data.s = table->data.s + key->data.si;
-      ret->size = 1;
+      char *buf = malloc(2);
+      buf[0] = table->data.s[key->data.si];
+      buf[1] = 0;
+      rain_set_strcpy(ret, buf, 2);
+      free(buf);
     }
     else if(key->data.si < 0 && key->data.si >= -(table->size)) {
-      ret->type = ITYP_STR;
-      ret->data.s = table->data.s + table->size + ret->data.si;
-      ret->size = 1;
+      char *buf = malloc(2);
+      buf[0] = table->data.s[table->size + key->data.si];
+      buf[1] = 0;
+      rain_set_strcpy(ret, buf, 2);
+      free(buf);
     }
     return;
   }


### PR DESCRIPTION
Also copy character at index into its own string instead of
pointing into the indexed string. This way we are protected
if and when the indexed string is garbage collected.

Fix #18