### PR TITLE
core: Handle null return in getenv

### DIFF
--- a/core/env/env.c
+++ b/core/env/env.c
@@ -15,5 +15,7 @@ void rain_init_args(int argc, char **argv) {
 
 void rain_ext_get_env(box *ret, box *val) {
   char *env = getenv(val->data.s);
-  rain_set_strcpy(ret, env, strlen(env));
+  if(env) {
+    rain_set_strcpy(ret, env, strlen(env));
+  }
 }


### PR DESCRIPTION
Fix #97