### PR TITLE
Add explicit capturing of non-local variables for closures

### DIFF
--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -3,6 +3,7 @@ program :: (stmt NEWLINE)+ EOF
 block :: INDENT (stmt NEWLINE)+ DEDENT
 
 stmt :: 'var' var_prefix ('=' compound)?
+      | 'bind' NAME (',' NAME)*
       | 'export' NAME '=' compound
       | 'foreign' (NAME | STRING) '=' NAME
       | 'import' (NAME '=')? import_mod

--- a/rain/ast.py
+++ b/rain/ast.py
@@ -120,6 +120,15 @@ class assn_node(node):
     self.export = export
 
 
+class bind_node(node):
+  __tag__ = 'bind'
+  __version__ = 1
+  __slots__ = ['names']
+
+  def __init__(self, names):
+    self.names = names
+
+
 class break_node(node):
   __tag__ = 'break'
   __version__ = 1

--- a/rain/base/file/_pkg.rn
+++ b/rain/base/file/_pkg.rn
@@ -22,6 +22,7 @@ base.close = func(self)
 
 base.lines = func(self)
   return func()
+    bind self
     return self:readline()
 
 export open = func(name, mode)

--- a/rain/base/iter.rn
+++ b/rain/base/iter.rn
@@ -1,6 +1,7 @@
 export count_by = func(step)
   var next = 0
   return func()
+    bind next, step
     save next
     next = next + step
 
@@ -9,6 +10,7 @@ export count = func() -> count_by(1)
 export srange_by = func(start, end, step)
   var next = start
   return func()
+    bind next, end, step
     if next < end
       save next
     next = next + step
@@ -19,6 +21,7 @@ export range = func(end) -> srange_by(0, end, 1)
 
 export map = func(iter, fn)
   return func()
+    bind iter, fn
     var val = iter()
     if val != null
       return fn(val)
@@ -31,6 +34,7 @@ export foldl = func(iter, fn, z)
 
 export map_success = func(iter, f)
   return func ()
+    bind iter, f
     var a = iter()
     while a != null
       a = f(a)
@@ -39,11 +43,16 @@ export map_success = func(iter, f)
       a = iter()
 
 export filter = func(iter, f)
-  return map_success(iter, func(a) -> f(a) & a | null)
+  var test = func(a)
+    bind f
+    return f(a) & a | null
+
+  return map_success(iter, test)
 
 export enum = func(iter)
   var i = 0
   return func()
+    bind i, iter
     var next = iter()
     if next == null
       return
@@ -53,6 +62,7 @@ export enum = func(iter)
 
 export zip = func(one, two)
   return func()
+    bind one, two
     var n1 = one()
     var n2 = two()
     if n1 == null | n2 == null
@@ -62,6 +72,7 @@ export zip = func(one, two)
 
 export zip_with = func(one, two, fn)
   return func()
+    bind one, two, fn
     var n1 = one()
     var n2 = two()
     if n1 == null | n2 == null
@@ -72,6 +83,7 @@ export zip_with = func(one, two, fn)
 export take = func(iter, end)
   var next = 0
   return func()
+    bind next, iter, end
     if next < end
       save iter()
     next = next + 1
@@ -86,10 +98,12 @@ export drop = func(iter, num)
 
 export repeat = func(val)
   return func()
+    bind val
     return val
 
 export replicate = func(times, val)
   return func()
+    bind times, val
     if times > 0
       times = times - 1
       return val

--- a/rain/core/ast.rn
+++ b/rain/core/ast.rn
@@ -44,6 +44,7 @@ _block.add = func(self, stmt)
 _block.values = func(self)
   var i = 0
   return func()
+    bind i, self
     save self.stmts[i]
     i = i + 1
 
@@ -71,6 +72,13 @@ export _export = table :: _assn
 
 _export._export = true
 
+export _bind = table :: node
+
+_bind.tag = "bind"
+_bind.slots = ["names"]
+_bind.new = func(self, names)
+  save ret = table :: self
+  ret.names = names
 
 export _break = table :: node
 

--- a/rain/core/except/_pkg.rn
+++ b/rain/core/except/_pkg.rn
@@ -20,6 +20,10 @@ fpe.msg = "floating point error"
 export segfault = table :: error
 segfault.msg = "segmentation fault"
 
+export unbound_var = table :: error
+unbound_var.msg = "unbound variable"
+
+foreign "rain_exc_unbound_var" = unbound_var
 foreign "rain_exc_arg_mismatch" = arg_mismatch
 foreign "rain_exc_error" = error
 foreign "rain_exc_fpe" = fpe

--- a/rain/core/except/except.h
+++ b/rain/core/except/except.h
@@ -65,5 +65,6 @@ box *rain_exc_uncallable;
 box *rain_exc_interrupt;
 box *rain_exc_fpe;
 box *rain_exc_segfault;
+box *rain_exc_unbound_var;
 
 #endif

--- a/rain/core/types/array.rn
+++ b/rain/core/types/array.rn
@@ -7,12 +7,14 @@ export length = foreign "rain_ext_array_length"(val)
 export values = func(self)
   var i = 0
   return func()
+    bind i, self
     save self[i]
     i = i + 1
 
 export keys = func(self)
   var i = 0
   return func()
+    bind i, self
     if self[i] == null
       return
 
@@ -22,6 +24,7 @@ export keys = func(self)
 export items = func(self)
   var i = 0
   return func()
+    bind i, self
     if self[i] == null
       return null
 

--- a/rain/core/types/int.rn
+++ b/rain/core/types/int.rn
@@ -7,6 +7,7 @@ export str = foreign "rain_ext_int_str"(self)
 
 export times = func(self)
   return func(block)
+    bind self
     var i = 0
     while i < self
       block(i)

--- a/rain/core/types/str.rn
+++ b/rain/core/types/str.rn
@@ -36,6 +36,7 @@ export split = func(s, at)
   var arr = table
   var arr_idx = 0
   var recurse = func(s)
+    bind arr, arr_idx, at, recurse
     if s == null | s == ""
       return
     var i = index_of(s, at)

--- a/rain/emit.py
+++ b/rain/emit.py
@@ -619,7 +619,7 @@ def emit(self, module):
       # cheesy hack - the only time any of these values will ever
       # have a bound value of False will be when it's the item
       # currently being bound, ie, it's this function
-      if getattr(ptr, 'bound', None) is False:
+      if getattr(module[name], 'bound', None) is False:
         module.runtime.put(env_ptr, key_ptr, self_ptr)
       else:
         module.runtime.put(env_ptr, key_ptr, module[name])

--- a/rain/emit.py
+++ b/rain/emit.py
@@ -160,7 +160,7 @@ def emit_local(self, module):
   with module.goto_entry():
     key_ptr = module.alloc()
 
-  env_ptr = module.ret_ptr
+  env_ptr = module.bind_ptr
 
   for i, name in enumerate(self.names):
     module.store(A.str_node(name).emit(module), key_ptr)
@@ -172,8 +172,6 @@ def emit_local(self, module):
       module.runtime.panic(module.load_exception('unbound_var'))
 
     module.bindings.add(name)
-
-  module.store(T.null, module.ret_ptr)
 
 
 @A.break_node.method

--- a/rain/emit.py
+++ b/rain/emit.py
@@ -165,6 +165,12 @@ def emit_local(self, module):
   for i, name in enumerate(self.names):
     module.store(A.str_node(name).emit(module), key_ptr)
     module[name] = module.runtime.get_ptr(env_ptr, key_ptr)
+    module[name].bound = True
+
+    is_null = module.builder.icmp_unsigned('==', module[name], T.arg(None))
+    with module.builder.if_then(is_null):
+      module.runtime.panic(module.load_exception('unbound_var'))
+
     module.bindings.add(name)
 
   module.store(T.null, module.ret_ptr)

--- a/rain/emit.py
+++ b/rain/emit.py
@@ -569,11 +569,6 @@ def emit_local(self, module):
 
 @A.func_node.method
 def emit(self, module):
-  env = OrderedDict()
-  for scope in module.scopes[1:]:
-    for nm, ptr in scope.items():
-      env[nm] = ptr
-
   typ = T.vfunc(T.arg, *[T.arg for x in self.params])
 
   func = module.add_func(typ, name=self.rename)
@@ -595,10 +590,6 @@ def emit(self, module):
         module.builder.ret_void()
 
   func_box = T._func(func, len(self.params))
-
-  if env and not bindings:
-    Q.warn('Is this function trying to implicitly close?', pos=self.coords)
-    print('  ', set(env))
 
   if bindings:
     env_ptr = module.runtime.new_table()

--- a/rain/lexer.py
+++ b/rain/lexer.py
@@ -29,9 +29,9 @@ KW_OPERATORS = (
 )
 
 KEYWORDS = (
-  'as', 'break', 'catch', 'continue', 'else', 'export', 'for', 'foreign',
-  'func', 'if', 'import', 'in', 'var', 'library', 'link', 'loop', 'macro',
-  'pass', 'return', 'save', 'until', 'while', 'with',
+  'as', 'bind', 'break', 'catch', 'continue', 'else', 'export', 'for',
+  'foreign', 'func', 'if', 'import', 'in', 'var', 'library', 'link', 'loop',
+  'macro', 'pass', 'return', 'save', 'until', 'while', 'with',
 )
 
 

--- a/rain/module.py
+++ b/rain/module.py
@@ -124,6 +124,7 @@ class Module(S.Scope):
     self.loop = None
     self.after = None
     self.ret_ptr = None
+    self.bind_ptr = None
     self.bindings = None
 
     self.name_counter = 0
@@ -236,7 +237,7 @@ class Module(S.Scope):
 
   @contextmanager
   def add_func_body(self, func):
-    with self.stack('ret_ptr', 'arg_ptrs', 'landingpad', 'bindings'):
+    with self.stack('ret_ptr', 'bind_ptr', 'arg_ptrs', 'landingpad', 'bindings'):
       entry = func.append_basic_block('entry')
       body = func.append_basic_block('body')
       self.bindings = set()
@@ -244,6 +245,12 @@ class Module(S.Scope):
       self.arg_ptrs = []
       self.landingpad = None
       with self.add_builder(entry):
+        # create a pointer using the incoming binding data
+        if self.ret_ptr.type == T.arg:
+          self.bind_ptr = self.alloc()
+          self.store(self.load(self.ret_ptr), self.bind_ptr)
+          self.store(T.null, self.ret_ptr)
+
         self.builder.branch(body)
 
       with self.add_builder(body):

--- a/rain/module.py
+++ b/rain/module.py
@@ -124,6 +124,7 @@ class Module(S.Scope):
     self.loop = None
     self.after = None
     self.ret_ptr = None
+    self.bindings = None
 
     self.name_counter = 0
 
@@ -235,9 +236,10 @@ class Module(S.Scope):
 
   @contextmanager
   def add_func_body(self, func):
-    with self.stack('ret_ptr', 'arg_ptrs', 'landingpad'):
+    with self.stack('ret_ptr', 'arg_ptrs', 'landingpad', 'bindings'):
       entry = func.append_basic_block('entry')
       body = func.append_basic_block('body')
+      self.bindings = set()
       self.ret_ptr = func.args[0]
       self.arg_ptrs = []
       self.landingpad = None

--- a/rain/parser.py
+++ b/rain/parser.py
@@ -217,6 +217,7 @@ def block(ctx):
 
 
 # stmt :: 'var' var_prefix ('=' compound)?
+#       | 'bind' NAME (',' NAME)*
 #       | 'export' NAME '=' compound
 #       | 'foreign' (NAME | STRING) '=' NAME
 #       | 'import' (NAME '=')? import_mod
@@ -243,6 +244,10 @@ def stmt(ctx):
     if ctx.consume(K.symbol_token('=')):
       rhs = compound(ctx)
     return A.assn_node(lhs, rhs, var=True)
+
+  if ctx.consume(K.keyword_token('bind')):
+    names = fnparams(ctx, parens=False)
+    return A.bind_node(names)
 
   if ctx.consume(K.keyword_token('export')):
     name = ctx.require(K.name_token).value

--- a/rain/parser.py
+++ b/rain/parser.py
@@ -636,6 +636,7 @@ def compound(ctx):
     return macro_exp(ctx)
 
   if ctx.consume(K.keyword_token('func')):
+    pos = ctx.past[-1]
     rename = None
     if ctx.expect(K.name_token, K.string_token):
       rename = ctx.require(K.name_token, K.string_token).value
@@ -644,10 +645,16 @@ def compound(ctx):
 
     if ctx.consume(K.operator_token('->')):
       exp = binexpr(ctx)
-      return A.func_node(params, A.return_node(exp))
+
+      node = A.func_node(params, A.return_node(exp))
+      node.coords = pos
+      return node
 
     body = block(ctx)
-    return A.func_node(params, body, rename)
+
+    node = A.func_node(params, body, rename)
+    node.coords = pos
+    return node
 
   if ctx.consume(K.keyword_token('catch')):
     body = block(ctx)
@@ -714,10 +721,14 @@ def unexpr(ctx):
 #         | primary
 def simple(ctx):
   if ctx.consume(K.keyword_token('func')):
+    pos = ctx.past[-1]
     params = fnparams(ctx)
     ctx.require(K.operator_token('->'))
     exp = binexpr(ctx)
-    return A.func_node(params, A.return_node(exp))
+
+    node = A.func_node(params, A.return_node(exp))
+    node.coords = pos
+    return node
 
   if ctx.consume(K.keyword_token('foreign')):
     name = ctx.require(K.name_token, K.string_token).value

--- a/rain/scope.py
+++ b/rain/scope.py
@@ -31,7 +31,7 @@ class Scope:
     self.pop()
 
   def __getitem__(self, key):
-    for scope in self.scopes[::-1]:
+    for scope in (self.top, self.globals):
       if key in scope:
         return scope[key]
     raise KeyError('Key {!r} not found'.format(key))
@@ -40,7 +40,7 @@ class Scope:
     self.top[key] = val
 
   def __contains__(self, key):
-    for scope in self.scopes:
+    for scope in (self.top, self.globals):
       if key in scope:
         return True
     return False

--- a/samples/advanced/for.rn
+++ b/samples/advanced/for.rn
@@ -3,6 +3,7 @@
 var range = func(n)
   var i = 0
   return func()
+    bind i, n
     if i == n
       return
 

--- a/tests/outputs/for.lex
+++ b/tests/outputs/for.lex
@@ -16,6 +16,11 @@ keyword 'func'
 symbol '('
 symbol ')'
 indent
+keyword 'bind'
+name 'i'
+symbol ','
+name 'n'
+newline
 keyword 'if'
 name 'i'
 operator '=='

--- a/tests/outputs/for.yml
+++ b/tests/outputs/for.yml
@@ -20,6 +20,10 @@ stmts:
           body: !block;2
             expr: null
             stmts:
+            - !bind;1
+              names:
+              - i
+              - n
             - !if;1
               body: !block;2
                 expr: null

--- a/tests/rain/iters.rn
+++ b/tests/rain/iters.rn
@@ -19,7 +19,9 @@ export main = func()
       return true
 
   var compose = func(f, g)
-    return func(x) -> f(g(x))
+    return func(x)
+      bind f, g
+      return f(g(x))
 
   @unit.group map_and_filter
     array.shallow_compare(
@@ -35,16 +37,16 @@ export main = func()
       array.from_iter(iter.map_success(([1,2,3,1,2,1]):values(), test_1)),
       [true, false, false, true, false, true])
 
-
-  var mk_t = {x=0}
+  var x = 0
   var mk = func()
-    mk_t.x = mk_t.x + 1
-    return mk_t.x < 10 & true | null
+    bind x
+    x = x + 1
+    return (x < 10) & true | null
 
 
   iter.force(mk)
 
   @unit.group forcing
-    mk_t.x == 10
+    mk.x == 10
 
   @unit.report


### PR DESCRIPTION
This also resolves a few stranger bugs relating to closures.

The explicit bindings make more sense with the way that Rain creates closure environments; it (hopefully) indicates that the inner variable is a copy rather than just referencing to the outer variable. On top of that, this is influenced by Jai's mechanism to help facilitate the transition from inline code, to a scoped block, an internal function, to an external function; it makes it very clear which variables will be used in the closure while making it impossible for it to accidentally refer to outer variables. 